### PR TITLE
Also support PHP8 for compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"keywords": ["polyfill", "php8", "tokenizer"],
 	"homepage": "https://php.watch/versions/8.0/PhpToken",
 	"require": {
-		"php": "^7.1",
+		"php": ">=7.1",
 		"ext-tokenizer": "*"
 	},
 	"require-dev": {


### PR DESCRIPTION
When having packages that should support php 7.x and PHP8, this package prevents installing on PHP8, while this would not be a problem as the composer autoloader only will load the class when it is not available. In PHP8 the PHPToken class is available by default.